### PR TITLE
Auto complete all missing locations on goal.

### DIFF
--- a/Archipelago.RiskOfRain2/ArchipelagoClient.cs
+++ b/Archipelago.RiskOfRain2/ArchipelagoClient.cs
@@ -270,7 +270,10 @@ namespace Archipelago.RiskOfRain2
         {
             // If ending is acceptable, finish the archipelago run.
             if (IsEndingAcceptable(gameEndingDef))
-            {
+            {                
+                // Auto-complete all remaining locations. Substitute for deprecated forced_auto_forfeit.
+                session.Locations.CompleteLocationChecks(session.Locations.AllMissingLocations.ToArray());
+             
                 var packet = new StatusUpdatePacket();
                 packet.Status = ArchipelagoClientState.ClientGoal;
                 session.Socket.SendPacket(packet);


### PR DESCRIPTION
This will complete all remaining locations when the goal has been met. 

## Why?
When `forced_auto_forfeit` is removed from AP server, completing RoR2 will not send out all locations anymore. This change would work around that limitation.