### PR TITLE
Increase scavenger spawn rate when scavengers are the only type of checks remaining (in a specific environment)

### DIFF
--- a/Archipelago.RiskOfRain2/ArchipelagoClient.cs
+++ b/Archipelago.RiskOfRain2/ArchipelagoClient.cs
@@ -32,6 +32,9 @@ namespace Archipelago.RiskOfRain2
         internal DeathLinkHandler Deathlinkhandler { get; private set; }
         internal StageBlockerHandler Stageblockerhandler { get; private set; }
         internal LocationHandler Locationhandler { get; private set; }
+        
+        internal ScavengerSpawnBoosterHandler ScavengerSpawnBoosterHandler { get; private set; }
+
 
         public ArchipelagoItemLogicController ItemLogic;
         public ArchipelagoLocationCheckProgressBarUI itemCheckBar;
@@ -148,7 +151,7 @@ namespace Archipelago.RiskOfRain2
                     ItemLogic.Stageblockerhandler = Stageblockerhandler;
                     Stageblockerhandler.BlockAll();
                     Locationhandler = new LocationHandler(session, LocationHandler.buildTemplateFromSlotData(successResult.SlotData));
-
+                    ScavengerSpawnBoosterHandler = new ScavengerSpawnBoosterHandler(Locationhandler);
                     // TODO there is a more likely a more reasonable location to create the UI for explore mode
                     itemCheckBar = new ArchipelagoLocationCheckProgressBarUI(new Vector2(-40, 0), Vector2.zero, "Item Check Progress:");
 
@@ -231,6 +234,7 @@ namespace Archipelago.RiskOfRain2
 
             Stageblockerhandler?.Hook();
             Locationhandler?.Hook();
+            ScavengerSpawnBoosterHandler?.Hook();
             ArchipelagoConsoleCommand.OnArchipelagoDeathLinkCommandCalled += ArchipelagoConsoleCommand_OnArchipelagoDeathLinkCommandCalled;
         }
 

--- a/Archipelago.RiskOfRain2/Handlers/LocationHandler.cs
+++ b/Archipelago.RiskOfRain2/Handlers/LocationHandler.cs
@@ -17,7 +17,7 @@ namespace Archipelago.RiskOfRain2.Handlers
         // NOTE every mention of a "environment" refers to the risk of rain 2 scenes that are loaded and played
 
 
-        // setup all scene indexes as megic numbers
+        // setup all scene indexes as magic numbers
         // scenes from https://risk-of-thunder.github.io/R2Wiki/Mod-Creation/Developer-Reference/Scene-Names/
         // main scenes
         public const int ancientloft = 3;       // Aphelian Sanctuary
@@ -142,6 +142,11 @@ namespace Archipelago.RiskOfRain2.Handlers
         private ArchipelagoSession session;
         private LocationInformationTemplate originallocationstemplate;
         private Dictionary<int, LocationInformationTemplate> currentlocations;
+
+        public LocationInformationTemplate GetLocationsForEnvironment(int environment)
+        {
+            return currentlocations.TryGetValue(environment, out var locInf) ? locInf : null;
+        }
 
         public LocationHandler(ArchipelagoSession session, LocationInformationTemplate locationstemplate)
         {

--- a/Archipelago.RiskOfRain2/Handlers/ScavengerSpawnBoosterHandler.cs
+++ b/Archipelago.RiskOfRain2/Handlers/ScavengerSpawnBoosterHandler.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using R2API;
+using R2API.Utils;
+using RoR2;
+
+namespace Archipelago.RiskOfRain2.Handlers;
+
+public class ScavengerSpawnBoosterHandler : IHandler
+{
+    private readonly LocationHandler _locationHandler;
+
+    internal ScavengerSpawnBoosterHandler(LocationHandler locationHandler)
+    {
+        _locationHandler = locationHandler;
+    }
+
+    public void Hook()
+    {
+        DirectorAPI.MonsterActions += OnMonsterActions;
+    }
+
+    private void OnMonsterActions(DccsPool dccsPool, List<DirectorAPI.DirectorCardHolder> directorCardHolders,
+        DirectorAPI.StageInfo stageInfo)
+    {
+        var stageInt = GetStageInt(stageInfo.stage);
+        var info = _locationHandler.GetLocationsForEnvironment(stageInt)!;
+        var scavengersRemaining = info[LocationHandler.LocationTypes.scavenger];
+        Log.LogInfo($"OnMonsterActions, scavengers remaining : {scavengersRemaining}");
+        if (scavengersRemaining > 0 && info.total() == scavengersRemaining)
+        {
+            var scavengerCardHolder = directorCardHolders
+                .Single(s => s.IsMonster
+                             && s.Card is { spawnCard: CharacterSpawnCard csc }
+                             && csc.name.ToLower() == DirectorAPI.Helpers.MonsterNames.Scavenger.ToLower()
+                );
+            
+            Log.LogInfo($"Card found : {scavengerCardHolder}");
+            Log.LogInfo($"Original cost : {scavengerCardHolder.Card.spawnCard.directorCreditCost}");
+            scavengerCardHolder.Card.spawnCard.directorCreditCost = 500;
+            //todo restore cost when exiting game or changing level, this edit is permanent
+            Log.LogInfo($"New cost : {scavengerCardHolder.Card.cost}");
+        }
+    }
+
+    private int GetStageInt(DirectorAPI.Stage stageInfoStage)
+    {
+        return stageInfoStage switch
+        {
+            DirectorAPI.Stage.AphelianSanctuary => LocationHandler.ancientloft,
+            DirectorAPI.Stage.DistantRoost => LocationHandler.blackbeach,
+            DirectorAPI.Stage.AbyssalDepths => LocationHandler.dampcavesimple,
+            DirectorAPI.Stage.WetlandAspect => LocationHandler.foggyswamp,
+            DirectorAPI.Stage.RallypointDelta => LocationHandler.frozenwall,
+            DirectorAPI.Stage.TitanicPlains => LocationHandler.golemplains,
+            DirectorAPI.Stage.AbandonedAqueduct => LocationHandler.goolake,
+            DirectorAPI.Stage.SunderedGrove => LocationHandler.rootjungle,
+            DirectorAPI.Stage.SirensCall => LocationHandler.shipgraveyard,
+            DirectorAPI.Stage.SkyMeadow => LocationHandler.skymeadow,
+            DirectorAPI.Stage.SiphonedForest => LocationHandler.snowyforest,
+            DirectorAPI.Stage.SulfurPools => LocationHandler.sulfurpools,
+            DirectorAPI.Stage.ScorchedAcres => LocationHandler.wispgraveyard,
+            _ => throw new ArgumentOutOfRangeException(nameof(stageInfoStage), stageInfoStage, null)
+        };
+    }
+
+    public void UnHook()
+    {
+        DirectorAPI.MonsterActions += OnMonsterActions;
+    }
+}


### PR DESCRIPTION
This PR lowers the cost of scavengers for the monster director when the only type of checks remaining in the current environment are scavengers.

It is marked as draft because right now the edit is permanent and even survives restarting a game, I still need to reset it when changing environment or exiting. 